### PR TITLE
clone all commits in data build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
   allow_failures:
     - env: SDG_REF="develop"
 sudo: false
+git:
+  depth: false
 
 branches:
   only:


### PR DESCRIPTION
See ONSdigital/sdg-data#32. This was an issue whereby the "last updated" field was incorrect because the build was not cloning the whole repository each time. So only the most recent edits were being picked up.