### PR TITLE
1.4.1 metadata - switch to 'bar'

### DIFF
--- a/meta/1-4-1.md
+++ b/meta/1-4-1.md
@@ -4,7 +4,7 @@ data_show_map: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
 graph_title: ' Proportion of population living in households with access to basic services'
-graph_type: line
+graph_type: bar
 indicator: 1.4.1
 computation_units: Percentage (%)
 national_geographical_coverage: Rwanda


### PR DESCRIPTION
@fsharangabo @norberthabimana @nechri @johnkab 
This indicator has a just data for a single year, so I've changed the graph type to 'bar'. Optional but recommended.
Take a look: https://sustainabledevelopment-rwanda.github.io/sdg-indicators/1-4-1/