### PR TITLE
Add notapplicable to _prose.yml

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -133,12 +133,18 @@ prose:
             element: select 
             label: "Reporting status"
             options:
-              - name: 'notstarted'
-                value: 'notstarted'
-              - name: 'inprogress'
-                value: 'inprogress'
               - name: 'complete'
                 value: 'complete'
+                translation_key: 'status.reported_online'
+              - name: 'inprogress'
+                value: 'inprogress'
+                translation_key: 'status.statistics_in_progress'
+              - name: 'notstarted'
+                value: 'notstarted'
+                translation_key: 'status.exploring_data_sources'
+              - name: 'notapplicable'
+                value: 'notapplicable'
+                translation_key: 'status.not_applicable'
             scope: data
       - name: data_non_statistical
         field:


### PR DESCRIPTION
There are now *four* reporting statuses available: `complete`, `inprogress`, `notstarted`, and `notapplicable`. These are understood and translated in open-sdg 0.5.0. This doesn't break anything so can be merged in ahead of an 0.5.0 upgrade.